### PR TITLE
URL refactoring, contribute button links, RuneLite stylization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Share your Old School Runescape Collection Log progress.
 
 ![](https://imgur.com/3vAkRJ0.png)
 
-Install the [Collection Log Runelite plugin](https://github.com/evansloan/collection-log) to automatically upload your Collection log data.
+Install the [Collection Log RuneLite plugin](https://github.com/evansloan/collection-log) to automatically upload your Collection log data.
 
 Want to contribute? Check out the [contributing guidelines](https://github.com/evansloan/collectionlog.net/blob/master/CONTRIBUTING.md)
 
@@ -12,4 +12,4 @@ Want to contribute? Check out the [contributing guidelines](https://github.com/e
 * [Site](https://collectionlog.net)
 * [API](https://github.com/evansloan/collection-log-api)
 * [Plugin](https://github.com/evansloan/collection-log)
-* [Runelite](https://runelite.net)
+* [RuneLite](https://runelite.net)

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
       content="Share your OSRS Collection Log progress"
     />
     <meta name="keywords" content="collection log,collection,log,osrs,runescape,old school">
-    <meta name="description" content="Share your Old School Runescape Collection Log progress. Keep track of your unique and total items obtained. Install the Runelite plugin to instantly share your Collection Log.">
+    <meta name="description" content="Share your Old School Runescape Collection Log progress. Keep track of your unique and total items obtained. Install the RuneLite plugin to instantly share your Collection Log.">
     <meta property="og:title" content="collectionlog.net">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://collectionlog.net">

--- a/src/components/elements/Button.tsx
+++ b/src/components/elements/Button.tsx
@@ -6,12 +6,13 @@ type HTMLButtonProps = DetailedHTMLElementProps<
 interface OverrideProps {
   title: string;
   icon?: string;
+  externalLink?: string;
 }
 
 type ButtonProps = HTMLButtonProps & OverrideProps;
 
 const Button = (props: ButtonProps) => {
-  return (
+  let buttonDom = (
     <button
       {...props}
       className={`p-2 bg-primary hover:bg-highlight border border-light text-white text-shadow ${props.className ?? ''}`}
@@ -24,6 +25,17 @@ const Button = (props: ButtonProps) => {
       </div>
     </button>
   );
+
+  // Wrap the button in an anchor if we should be redirecting outwards
+  if (props.externalLink) {
+    buttonDom = (
+      <a href={props.externalLink}>
+        {buttonDom}
+      </a>
+    );
+  }
+
+  return buttonDom;
 };
 
 export default Button;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -11,7 +11,7 @@ const Footer = () => {
         Install the {' '}
         <a href={pluginUrl}>Collection Log plugin</a> {' '}
         on {' '}
-        <a href='https://runelite.net'>Runelite</a>
+        <a href='https://runelite.net'>RuneLite</a>
       </p>
       <p>
         Have a problem or found a bug? Submit an issue on {' '}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,3 +1,5 @@
+import { gitHubUrl, pluginUrl } from '../../constants/Urls';
+
 const Footer = () => {
   return (
     <footer className='flex flex-wrap justify-around w-full mt-2 p-2 bg-primary border-t-4 border-t-black text-sm text-center shadow-log'>
@@ -7,13 +9,13 @@ const Footer = () => {
       </p>
       <p>
         Install the {' '}
-        <a href='https://runelite.net/plugin-hub/show/collection-log'>Collection Log plugin</a> {' '}
+        <a href={pluginUrl}>Collection Log plugin</a> {' '}
         on {' '}
         <a href='https://runelite.net'>Runelite</a>
       </p>
       <p>
         Have a problem or found a bug? Submit an issue on {' '}
-        <a href='https://github.com/evansloan/collectionlog.net/issues/new/choose'>Github</a>
+        <a href={gitHubUrl + '/issues/new/choose'}>GitHub</a>
       </p>
     </footer>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { CollectionLogAPI } from '../../api/log-api';
 import discordIcon from '../../assets/images/discord.png';
+import { discordUrl } from '../../constants/Urls';
 import { AccountIcon, Button, DropDown, Input } from '../elements';
 
 const Header = () => {
@@ -112,7 +113,7 @@ const Header = () => {
         <Link to='/hiscores/1'>Hiscores</Link>
         <div className='flex'>
           <img className='w-[25px] mr-2' src={discordIcon} />
-          <a href='https://discord.gg/loghunters'>Join the Log Hunters Discord server</a>
+          <a href={discordUrl}>Join the Log Hunters Discord server</a>
         </div>
       </div>
       <div className='flex md:hidden justify-around w-full mb-2 p-2 bg-primary border-b-4 border-b-black text-lg shadow-log sticky top-0 z-50'>
@@ -120,7 +121,7 @@ const Header = () => {
           <Link to='/'>Home</Link>
           <Link to='/hiscores/1'>Hiscores</Link>
           <div className='flex'>
-            <a href='https://discord.gg/loghunters'>Join the Log Hunters Discord server</a>
+            <a href={discordUrl}>Join the Log Hunters Discord server</a>
             <img className='w-[25px] ml-2' src={discordIcon} />
           </div>
         </DropDown>

--- a/src/constants/Urls.ts
+++ b/src/constants/Urls.ts
@@ -1,0 +1,5 @@
+export const discordUrl = 'https://discord.gg/loghunters';
+
+export const gitHubUrl = 'https://github.com/evansloan/collectionlog.net';
+
+export const pluginUrl = 'https://runelite.net/plugin-hub/show/collection-log';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { loadRecentItemsGlobal, loadStreams, loadUserCount } from '../app/reduce
 import logIcon from '../assets/images/collectionlog.png';
 import discordIcon from '../assets/images/discord.png';
 import githubIcon from '../assets/images/github.png';
+import { discordUrl, gitHubUrl, pluginUrl } from '../constants/Urls';
 import {
   Button,
   Item,
@@ -110,7 +111,7 @@ const Home = () => {
                 <h3>How do I upload my collection log?</h3>
                 <ol className='list-decimal text-white ml-3'>
                   <li>
-                    <p>Install the <a href=''>Collection Log Runelite plugin</a> from the Runelite plugin hub.</p>
+                    <p>Install the <a href={pluginUrl}>Collection Log Runelite plugin</a> from the Runelite plugin hub.</p>
                   </li>
                   <li>
                     <p>Open your collection log in-game and click through all pages in order to save a copy of your collection log.</p>
@@ -151,6 +152,7 @@ const Home = () => {
                   icon={discordIcon}
                   className='block w-1/4 m-auto bg-[#6A5ACD] hover:bg-[#6d67b6] text-lg'
                   title='Open in Discord'
+                  externalLink={discordUrl}
                 />
               </div>
               <div className='flex-1'>
@@ -160,6 +162,7 @@ const Home = () => {
                   icon={githubIcon}
                   className='block w-1/4 m-auto bg-black hover:bg-gray-500 text-lg'
                   title='View on GitHub'
+                  externalLink={gitHubUrl}
                 />
               </div>
             </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -111,7 +111,7 @@ const Home = () => {
                 <h3>How do I upload my collection log?</h3>
                 <ol className='list-decimal text-white ml-3'>
                   <li>
-                    <p>Install the <a href={pluginUrl}>Collection Log Runelite plugin</a> from the Runelite plugin hub.</p>
+                    <p>Install the <a href={pluginUrl}>Collection Log RuneLite plugin</a> from the RuneLite plugin hub.</p>
                   </li>
                   <li>
                     <p>Open your collection log in-game and click through all pages in order to save a copy of your collection log.</p>


### PR DESCRIPTION
Closes #35 

Refactor common URLs for re-use throughout the site into a constants folder/file.

Update the Button component to handle links when applicable.
Update the buttons on the "Contribute" home tab to navigate to discord/GitHub respectively.
Update link in FAQ to navigate to the plugin.

Stylize RuneLite, stylize GitHub.

Fair warning, this is my first time working with a React project, but I'm familiar with TypeScript alongside AngularJS / Angular.