### PR TITLE
Add indicator when item data out of sync.

### DIFF
--- a/src/app/reducers/log/slice.ts
+++ b/src/app/reducers/log/slice.ts
@@ -20,7 +20,27 @@ export const loadCollectionLog = createAsyncThunk(
     const api = CollectionLogAPI.getInstance();
     username = username.toLowerCase();
     const response = await api.getCollectionLog(username);
-    return response.data.collectionLog;
+
+    const collectionLog = response.data.collectionLog;
+
+    // Calculate uniques by item counts. This number may differ from the overall definitive uniques obtained if data is out of sync.
+    const uniquesObtainedByItemCount = new Set<number>();
+    for(const tabKey in collectionLog.tabs) {
+      const tab = collectionLog.tabs[tabKey];
+
+      for(const collectionLogEntryKey in tab) {
+        const collectionLogEntry = tab[collectionLogEntryKey];
+
+        for(const item of collectionLogEntry.items) {
+          if (item.obtained && !uniquesObtainedByItemCount.has(item.id)) {
+            uniquesObtainedByItemCount.add(item.id);
+          }
+        }
+      }
+    }
+    collectionLog.uniqueObtainedByItemCount = uniquesObtainedByItemCount.size;
+
+    return collectionLog;
   }
 );
 

--- a/src/pages/Log.tsx
+++ b/src/pages/Log.tsx
@@ -175,6 +175,12 @@ const Log = () => {
                 Obtained: <span className='text-white'>{collectionLog?.uniqueObtained}/{collectionLog?.uniqueItems}</span> {' '}
                 Rank: <span className='text-white'>#{logState.rank}</span>
               </p>
+              {(collectionLog && collectionLog?.uniqueObtained !== collectionLog?.uniqueObtainedByItemCount) ?
+                <p className='text-lg font-bold text-center text-yellow'>
+                  Total obtained does not match specific items collected. Please re-upload collection log data.
+                </p>
+                : null
+              }
             </PageHeader>
             <div className='md:mx-3 mb-3 md:mt-1 h-full border-2 border-t-0 border-light md:rounded-tr-[10px] md:rounded-tl-[10px] md:overflow-hidden'>
               <Tabs activeTab={activeTab} onClick={onTabClick}>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -35,8 +35,9 @@ interface CollectionLog {
   accountType: AccountType;
   totalObtained: number;
   totalitems: number;
-  uniqueObtained: number;
+  uniqueObtained: number; // The total uniques obtained as defined by the overview number
   uniqueItems: number;
+  uniqueObtainedByItemCount: number; // The total uniques obtained as defined by the sum of known obtained. If value doesn't match uniqueObtained, this is indicative of item data being out of sync.
 }
 
 interface RecentItems {


### PR DESCRIPTION
Closes #42 

Added indicator to the user log page when total item counts don't align with the total uniques obtained.

Wasn't sure of the proper place to put the logic, but wanted to only do it once on collection log load. I can refactor it into a service or React-equivalent if necessary.

Example when it doesn't apply:
![image](https://user-images.githubusercontent.com/10370516/228451624-52e292f3-af98-45ef-9aca-8ff1c666eb20.png)

Example when it does:
![image](https://user-images.githubusercontent.com/10370516/228451866-9a9275bf-0264-46e6-9ff4-238f0889c42f.png)