### PR TITLE
Navigate to user when clicking search typeahead

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -41,7 +41,7 @@ const Header = () => {
 
   const onTypeaheadClick = (username: string) => {
     setSearch(username);
-    setTypeahead([]);
+    onSearch();
   };
 
   const onSearch = () => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -40,16 +40,19 @@ const Header = () => {
   };
 
   const onTypeaheadClick = (username: string) => {
-    setSearch(username);
-    onSearch();
+    navigateToUser(username);
   };
 
   const onSearch = () => {
     if (search == '') {
       return;
     }
+    navigateToUser(search);
+  };
+
+  const navigateToUser = (username: string) => {
     setIsSearchOpen(false);
-    navigate(`log/${search}`);
+    navigate(`log/${username}`);
   };
 
   const onSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
Closes #46 

Clicking the search typeahead result will navigate to the user's page directly, instead of filling in the search bar.

![image](https://user-images.githubusercontent.com/10370516/229423187-d9163a93-c690-4572-aee5-d4c6205c6f95.png)
