### PR TITLE
Indicator when user's max items are less than expected

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -6,3 +6,7 @@ export enum AccountType {
   GROUP_IRONMAN = 'GROUP_IRONMAN',
   HARDCORE_GROUP_IRONMAN = 'HARDCORE_GROUP_IRONMAN'
 }
+
+export const discordUrl = 'https://discord.gg/loghunters';
+export const gitHubUrl = 'https://github.com/evansloan/collectionlog.net';
+export const pluginUrl = 'https://runelite.net/plugin-hub/show/collection-log';

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -10,3 +10,5 @@ export enum AccountType {
 export const discordUrl = 'https://discord.gg/loghunters';
 export const gitHubUrl = 'https://github.com/evansloan/collectionlog.net';
 export const pluginUrl = 'https://runelite.net/plugin-hub/show/collection-log';
+
+export const expectedMaxUniqueItems = 1443;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,4 +1,4 @@
-import { gitHubUrl, pluginUrl } from '../../constants/Urls';
+import { gitHubUrl, pluginUrl } from '../../app/constants';
 
 const Footer = () => {
   return (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { CollectionLogAPI } from '../../api/collection-log/collection-log-api';
 import discordIcon from '../../assets/images/discord.png';
-import { discordUrl } from '../../constants/Urls';
+import { discordUrl } from '../../app/constants';
 import { AccountIcon, Button, DropDown, Input } from '../elements';
 
 const Header = () => {

--- a/src/constants/Urls.ts
+++ b/src/constants/Urls.ts
@@ -1,5 +1,0 @@
-export const discordUrl = 'https://discord.gg/loghunters';
-
-export const gitHubUrl = 'https://github.com/evansloan/collectionlog.net';
-
-export const pluginUrl = 'https://runelite.net/plugin-hub/show/collection-log';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { loadRecentItemsGlobal, loadStreams, loadUserCount } from '../app/reduce
 import logIcon from '../assets/images/collectionlog.png';
 import discordIcon from '../assets/images/discord.png';
 import githubIcon from '../assets/images/github.png';
-import { discordUrl, gitHubUrl, pluginUrl } from '../constants/Urls';
+import { discordUrl, gitHubUrl, pluginUrl } from '../app/constants';
 import {
   Button,
   Item,

--- a/src/pages/Log.tsx
+++ b/src/pages/Log.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import DocumentMeta from 'react-document-meta';
 import { useParams } from 'react-router-dom';
 
-import { AccountType } from '../app/constants';
+import { AccountType, expectedMaxUniqueItems } from '../app/constants';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import {
   loadCollectionLog,
@@ -204,6 +204,11 @@ const Log = () => {
                 Obtained: <span className='text-white'>{collectionLog?.uniqueObtained}/{collectionLog?.uniqueItems}</span> {' '}
                 Rank: <span className='text-white'>#{logState.rank}</span>
               </p>
+              {collectionLog && collectionLog?.uniqueItems < expectedMaxUniqueItems &&
+                <p className='text-lg font-bold text-center text-yellow'>
+                  New unique items have been added to Old School RuneScape! Please re-upload collection log data.
+                </p>
+              }
               {collectionLog && collectionLog?.uniqueObtained !== explicitlyCountedUniques &&
                 <p className='text-lg font-bold text-center text-yellow'>
                   Total obtained does not match specific items collected. Please re-upload collection log data.


### PR DESCRIPTION
Closes #44

Adds an indicator that the user should re-sync their collection log data when we have less than the expected number of maximum uniques.

The constant will need to be updated when new items are added to the collection log.

Example when the user has >= expected max uniques (no indicator):
![image](https://user-images.githubusercontent.com/10370516/229706496-625fe5d6-e77a-413a-9a16-a820c5a49bd4.png)

Example when the user has < expected max uniques (indicator):
![image](https://user-images.githubusercontent.com/10370516/229707746-9cfcea32-bdd3-481a-b2a0-1dad2fcecc21.png)


Example when the user has < expected max uniques AND has an out-of-date item count (indicator):
![image](https://user-images.githubusercontent.com/10370516/229706768-162cab74-7961-4f89-921f-dfa8bc9eaf43.png)

