### PR TITLE
Fix page error by only showing available tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# JetBrains
+.idea/**/*

--- a/src/components/elements/Tabs.tsx
+++ b/src/components/elements/Tabs.tsx
@@ -4,14 +4,14 @@ import Tab from './Tab';
 
 interface OverrideProps {
   activeTab?: string;
-  children: React.ReactElement[];
+  children: React.ReactElement[] | undefined;
   onClick?: (tabName: string) => void;
 }
 
 type TabsProps = HTMLElementProps<OverrideProps>;
 
 const Tabs = (props: TabsProps) => {
-  const [activeTab, setActiveTab] = useState(props.activeTab ?? props.children[0].props['data-tab']);
+  const [activeTab, setActiveTab] = useState(props.activeTab ?? props.children?.[0].props['data-tab']);
   const className = props.className ?? '';
 
   useEffect(() => {
@@ -30,7 +30,7 @@ const Tabs = (props: TabsProps) => {
   return (
     <>
       <div className={`flex flex-wrap justify-between p-0 border-b-2 border-b-light ${className}`}>
-        {props.children.map((child) => {
+        {props.children && props.children.map((child) => {
           const label = child.props['data-tab'];
 
           return (
@@ -43,7 +43,7 @@ const Tabs = (props: TabsProps) => {
           );
         })}
       </div>
-      {props.children.map((child) => {
+      {props.children && props.children.map((child) => {
         if (child.props['data-tab'] != activeTab) {
           return undefined;
         }

--- a/src/pages/Log.tsx
+++ b/src/pages/Log.tsx
@@ -53,6 +53,14 @@ const Log = () => {
   const [activeTab, setActiveTab] = useState('Bosses');
   const [activeEntry, setActiveEntry] = useState(paramsEntry ?? 'Abyssal Sire');
 
+  const { collectionLog, isLoading } = logState;
+  const tabKeys = Object.keys(collectionLog?.tabs || []);
+
+  /**
+   * Alphabetical sorted tabs that are matched between the TAB constant and the retrieved tab from the collectionLog
+   */
+  const tabs = sortAlphabetical(TABS.filter((staticTab) => tabKeys.some((tabKey) => staticTab == tabKey)));
+
   /**
    * Load collection log data from API.
    *
@@ -82,15 +90,13 @@ const Log = () => {
     }
 
     if (paramsEntry) {
-      paramsTab = TABS.find((tabName) => {
+      paramsTab = tabs.find((tabName) => {
         const entry = logState.collectionLog?.tabs[tabName][paramsEntry];
         return entry != undefined;
       });
       setActiveTab(paramsTab ?? 'Bosses');
     }
   }, [logState.collectionLog]);
-
-  const { collectionLog, isLoading } = logState;
 
   const entryData = collectionLog?.tabs[activeTab][activeEntry];
   const obtainedCount = entryData?.items.filter((item) => item.obtained).length;
@@ -212,8 +218,8 @@ const Log = () => {
             </PageHeader>
             <div className='md:mx-3 mb-3 md:mt-1 h-full border-2 border-t-0 border-light md:rounded-tr-[10px] md:rounded-tl-[10px] md:overflow-hidden'>
               <Tabs activeTab={activeTab} onClick={onTabClick}>
-                {TABS.map((tabName) => {
-                  let entries = sortAlphabetical(Object.keys(collectionLog?.tabs[tabName] ?? []));
+                {collectionLog && tabs.map((tabName) => {
+                  let entries = sortAlphabetical(Object.keys(collectionLog.tabs[tabName] ?? []));
                   // Override alphabetical sort for clues
                   if (tabName == 'Clues') {
                     entries = CLUE_TAB_ENTRIES;
@@ -224,7 +230,7 @@ const Log = () => {
                       <div className='flex w-full h-[94%] md:overflow-hidden'>
                         <div id='entry-list' className='pb-5 w-full md:w-1/4 h-full border-black border-r shadow-log overflow-y-scroll hidden md:block'>
                           {entries.map((entryName, i) => {
-                            const entryItems = collectionLog?.tabs[tabName][entryName]?.items;
+                            const entryItems = collectionLog.tabs[tabName][entryName]?.items;
                             const entryObtained = entryItems?.filter((item) => {
                               return item.obtained;
                             }).length;


### PR DESCRIPTION
# Description
While uploading my character for the first time, the page errored (and I have found out that it happens quite a lot with other characters too). My character for reference in [production](https://collectionlog.net/log/Napokueman).

Reason for this is that my character's JSON does not have at least one collection from each of the tabs.

# Proposed solution - Only showing available tabs
Currently solution that I provide here with the PR is choosing to not show the tabs that my character for instance does not have. This causes the bug to be fixed.

![image](https://user-images.githubusercontent.com/6235760/229941849-4c789431-07c9-4bce-9440-4a75be90ab7d.png)

**However**, there is a downside to this solution and that is the user is not able to see the other tabs for them self and causes another user experience than other users.

# Alternative solution 1 - Show all tabs disabled
A possible solution would be to still show all tabs, while not having the tabs available in the collectionLog object. A check will be created that checks what tabs the user has data for and show those tabs enabled, while showing the tabs that don't have data as disabled.

# Alternative solution 2 - Show all tabs enabled with all data
Another possible solution will be to make always all tabs, entries, items available via a static way. Maybe having them retrieved once for a user from an API and cache it for some time.

# Alternative solution 3 - Change the JSON export
Probably the highest impact one, but a possible solution would be change the JSON export of the plugin and always include all the categories (i.e. the tabs). This would solve the problem at frontend.

# My export JSON
```json
{
    "total_obtained": 0,
    "total_items": 9,
    "unique_obtained": 18,
    "unique_items": 1443,
    "tabs": {
        "Bosses": {
            "Abyssal Sire": {
                "items": [
                    {
                        "id": 13262,
                        "name": "Abyssal orphan",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 25624,
                        "name": "Unsired",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 7979,
                        "name": "Abyssal head",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 13274,
                        "name": "Bludgeon spine",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 13275,
                        "name": "Bludgeon claw",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 13276,
                        "name": "Bludgeon axon",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 13277,
                        "name": "Jar of miasma",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 13265,
                        "name": "Abyssal dagger",
                        "quantity": 0,
                        "obtained": false
                    },
                    {
                        "id": 4151,
                        "name": "Abyssal whip",
                        "quantity": 0,
                        "obtained": false
                    }
                ],
                "kill_count": [
                    "Abyssal Sire kills: 0"
                ]
            }
        }
    }
}
```

