### PR TITLE
feat(Header): introduce check in typeahead cache before navigating

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -80,11 +80,31 @@ const Header = () => {
   }, [searchLength]);
 
   const filterTypeahead = (search: string) => {
-    const typeaheadVals = typeaheadCache.users.filter((user) => {
-      const username = user.username.toLowerCase();
-      return username.slice(0, search.length) == search.toLowerCase();
-    });
-    setTypeahead(typeaheadVals.slice(0, 5));
+    const maxShownResults = 5;
+    let matchedUsers = 0;
+    const filter: User[] = Array(maxShownResults);
+
+    if (search === '') {
+      setTypeahead(filter);
+      return;
+    }
+
+    const searchValue = search.toLowerCase();
+    for (const user of typeaheadCache.users) {
+      if (matchedUsers >= maxShownResults) {
+        break;
+      }
+
+      const partialUsername = user.username.toLowerCase().slice(0, search.length);
+      if (partialUsername !== searchValue) {
+        continue;
+      }
+
+      filter[matchedUsers] = user;
+      matchedUsers++;
+    }
+
+    setTypeahead(filter);
   };
 
   const onTypeaheadClick = (username: string) => {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -47,6 +47,11 @@ const Header = () => {
     if (search == '') {
       return;
     }
+
+    if (!typeahead.some((user) => user.username === search)) {
+      return;
+    }
+
     navigateToUser(search);
   };
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -62,11 +62,6 @@ const Header = () => {
       return;
     }
 
-    // To reduce the amount of fetched users, the search will be started at 2 characters
-    if (search.length === 1) {
-      return;
-    }
-
     // Only inputting spaces will not result in an API call
     if (search.trim() === '') {
       return;


### PR DESCRIPTION
As discussed in #53 a possible way to prevent a user to navigate to a collection log that does not exist.