### PR TITLE
Adds Tab/section progress indicators

### DIFF
--- a/src/components/elements/Tab.tsx
+++ b/src/components/elements/Tab.tsx
@@ -1,22 +1,30 @@
-import React from 'react';
-
 interface TabProps {
   activeTab: string;
   label: string;
+  obtainedUniques: number | undefined;
+  totalUniques: number | undefined;
   onTabClick: (tabName: string) => void;
 }
 
 const Tab = (props: TabProps) => {
-  const { activeTab, label, onTabClick } = props;
+  const { activeTab, label, obtainedUniques, totalUniques, onTabClick } = props;
 
   let className = 'bg-dark';
   if (activeTab == label) {
     className = 'bg-tabHighlight';
   }
 
+  // Eventually this setting will be a toggle-able user setting, until then it'll be feature flagged by this
+  const shouldShowTabProgress = true && obtainedUniques != null && totalUniques != null; // Not all tabs are collection log tabs
+
+  let progressColor = obtainedUniques == totalUniques ? 'text-green' : 'text-yellow';
+  if (obtainedUniques == 0) {
+    progressColor = 'text-red';
+  }
+
   return (
     <div className={`flex justify-center items-center grow px-[5px] py-0 max-w-[18%] min-w-full sm:min-w-[120px] hover:bg-highlight border-2 border-light border-b-0 md:rounded-tl-[10px] md:rounded-tr-[10px] cursor-pointer ${className}`} onClick={() => onTabClick(label)}>
-      <span className='text-orange text-center text-lg font-bold'>{label}</span>
+      <span className='text-orange text-center text-lg font-bold'>{label} {shouldShowTabProgress && <span className={progressColor}>{`(${obtainedUniques}/${totalUniques})`}</span>}</span>
     </div>
   );
 };

--- a/src/components/elements/Tabs.tsx
+++ b/src/components/elements/Tabs.tsx
@@ -32,12 +32,16 @@ const Tabs = (props: TabsProps) => {
       <div className={`flex flex-wrap justify-between p-0 border-b-2 border-b-light ${className}`}>
         {props.children && props.children.map((child) => {
           const label = child.props['data-tab'];
+          const obtainedUniques: number = child.props['data-obtainedUniques'];
+          const totalUniques: number = child.props['data-totalUniques'];
 
           return (
             <Tab
               activeTab={activeTab}
               key={label}
               label={label}
+              obtainedUniques={obtainedUniques}
+              totalUniques={totalUniques}
               onTabClick={onClickTabItem}
             />
           );

--- a/src/pages/Log.tsx
+++ b/src/pages/Log.tsx
@@ -98,6 +98,9 @@ const Log = () => {
     }
   }, [logState.collectionLog]);
 
+  // Eventually this setting will be a toggle-able user setting, until then it'll be feature flagged by this
+  const shouldShowSectionProgress = true;
+
   const entryData = collectionLog?.tabs[activeTab][activeEntry];
   const obtainedCount = entryData?.items.filter((item) => item.obtained).length;
   const itemCount = entryData?.items.length;
@@ -238,9 +241,15 @@ const Log = () => {
                             const entryItems = collectionLog.tabs[tabName][entryName]?.items;
                             const entryObtained = entryItems?.filter((item) => {
                               return item.obtained;
-                            }).length;
+                            }).length ?? 0;
+                            const totalEntryItems = entryItems?.length ?? 0;
                             const isComplete = entryObtained == entryItems?.length && entryItems;
                             const textColor = isComplete ? 'text-green' : 'text-orange';
+
+                            let sectionProgressColor = isComplete ? 'text-green' : 'text-yellow';
+                            if (entryObtained == 0) {
+                              sectionProgressColor = 'text-red';
+                            }
 
                             let bg = i % 2 == 0 ? 'bg-primary' : 'bg-light';
                             bg = entryName == activeEntry ? 'bg-highlight' : bg;
@@ -250,7 +259,7 @@ const Log = () => {
                                 className={`${bg} hover:bg-highlight ${textColor} text-lg cursor-pointer`}
                                 onClick={() => onEntryClick(entryName)}
                                 key={entryName}>
-                                {entryName}
+                                {entryName} {shouldShowSectionProgress && (<span className={sectionProgressColor}>{` (${entryObtained}/${totalEntryItems})`}</span>)}
                               </p>
                             );
                           })}

--- a/src/pages/Log.tsx
+++ b/src/pages/Log.tsx
@@ -233,8 +233,25 @@ const Log = () => {
                     entries = CLUE_TAB_ENTRIES;
                   }
 
+                  // Count the number of uniques and totals for the tab
+                  const uniqueTabItemIds = new Set<number>();
+                  const uniqueTabItemIdsObtained = new Set<number>();
+
+                  for(const collectionLogEntryKey in collectionLog.tabs[tabName] ?? []) {
+                    const collectionLogEntry = collectionLog.tabs[tabName][collectionLogEntryKey];
+
+                    for(const item of collectionLogEntry.items) {
+                      if (!uniqueTabItemIds.has(item.id)) {
+                        uniqueTabItemIds.add(item.id);
+                      }
+                      if (item.obtained && !uniqueTabItemIdsObtained.has(item.id)) {
+                        uniqueTabItemIdsObtained.add(item.id);
+                      }
+                    }
+                  }
+
                   return (
-                    <div key={tabName} data-tab={tabName}>
+                    <div key={tabName} data-tab={tabName} data-obtainedUniques={uniqueTabItemIdsObtained.size} data-totalUniques={uniqueTabItemIds.size}>
                       <div className='flex w-full h-[94%] md:overflow-hidden'>
                         <div id='entry-list' className='pb-5 w-full md:w-1/4 h-full border-black border-r shadow-log overflow-y-scroll hidden md:block'>
                           {entries.map((entryName, i) => {


### PR DESCRIPTION
Closes #45 

Adds colored indicators to tabs and sections, showing the areas that are in-progress.
The counts on the tab will be the number of uniques, not total if there are shared items in different sections.

Original issue in #45 only dances around the idea of the indicators on tabs, unsure if it's what we want. I've implemented it in a separate commit so we can easily roll it back if we decide it's not the route we want to go.

The code for getting uniques in the tab is not as DRY as I'd like, but I couldn't think of a good way to refactor since it has different inner logic than the total unique finder.

Examples:
![image](https://user-images.githubusercontent.com/10370516/232970083-fc03e05a-cacd-49af-9011-10a998ea17ec.png)

![image](https://user-images.githubusercontent.com/10370516/232971206-97c3458f-a6d4-4d18-ac35-dcaef97d99b0.png)

![image](https://user-images.githubusercontent.com/10370516/232971269-12731e86-8bcb-4ea8-8710-832241b9a14d.png)

